### PR TITLE
Fix tabby incompatibility

### DIFF
--- a/lua/true-zen/ataraxis.lua
+++ b/lua/true-zen/ataraxis.lua
@@ -164,6 +164,7 @@ function M.on()
 	layout("generate")
 
 	o.fillchars = "stl: ,stlnc: ,vert: ,diff: ,msgsep: ,eob: "
+	o.showtabline = 0
 
 	for hi_group, _ in pairs(original_opts["highlights"]) do
 		colors.highlight(hi_group, { bg = base, fg = base })


### PR DESCRIPTION
Tabby.nvim [sets an autocommand for `TabNew`](https://github.com/nanozuki/tabby.nvim/blob/c473f1ac3db262605b716afcb570f46f27fe8eb3/lua/tabby/init.lua#L20) which [sets `'showtabline'` to 2](https://github.com/nanozuki/tabby.nvim/blob/c473f1ac3db262605b716afcb570f46f27fe8eb3/lua/tabby/init.lua#L37-L44). When Ataraxis mode runs `tabedit`, this triggers the autocommand and messes up the view as shown below. (The visible status lines are a separate issue.)

![Screen Shot 2022-08-02 at 1 49 29 AM](https://user-images.githubusercontent.com/38332081/182310286-5ca0e125-4b6c-4564-85f3-97680c104f71.png)

This commit simply re-sets `'showtabline'` to 0 after running `tabedit` so that the tabline stays hidden.