### PR TITLE
Fix listchars being visible in ataraxis padding windows

### DIFF
--- a/lua/true-zen/ataraxis.lua
+++ b/lua/true-zen/ataraxis.lua
@@ -46,6 +46,7 @@ local opts = {
 		number = false,
 		relativenumber = false,
 		foldenable = false,
+		list = false,
 	},
 }
 


### PR DESCRIPTION
(Ignore the status lines being visible, that's a separate issue >:) )

# Before

![Screen Shot 2022-08-02 at 2 00 35 AM](https://user-images.githubusercontent.com/38332081/182312241-f14073fb-41bb-4925-b70b-ebe6e5ec1678.png)

# After

![Screen Shot 2022-08-02 at 2 02 11 AM](https://user-images.githubusercontent.com/38332081/182312498-321b835c-18aa-4bfa-84b3-21bef848cc1b.png)