### PR TITLE
fix: NormalNC hlgroup messes up aesthetic of ataraxis

### DIFF
--- a/lua/true-zen/ataraxis.lua
+++ b/lua/true-zen/ataraxis.lua
@@ -61,6 +61,7 @@ local function save_opts()
 		VertSplit = colors.get_hl("VertSplit"),
 		SignColumn = colors.get_hl("SignColumn"),
 		WinBar = colors.get_hl("WinBar"),
+		NormalNC = colors.get_hl("NormalNC"),
 	}
 end
 


### PR DESCRIPTION
When a user uses the `NormalNC` highlight group which is great for focusing in normal vim usage, going into Ataraxis mode looks really bad because it has a border around it rather than appearing as a "single window with padding". This resolves this